### PR TITLE
Fix broken tag link when tag contains space

### DIFF
--- a/layouts/partials/article-header.html
+++ b/layouts/partials/article-header.html
@@ -6,7 +6,7 @@
 <footer class="post-info">{{ .Site.Data.l10n.article.posted_on }} <span class="post-meta"><time datetime="{{ .Date.Format "2006.01.02" }}">{{ .Date.Format "2006.01.02" }}</time>
 {{ if gt (len .Params.tags) 0 }}&middot; {{ .Site.Data.l10n.article.tagged_in }}
     {{ range $i, $v := .Params.tags }}
-    <a href="{{ $.Site.BaseURL }}tags/{{ $v | lower }}">{{ $v | lower }}</a>{{ if ne (len $.Params.tags) (add $i 1) }}, {{ end }}
+    <a href="{{ $.Site.BaseURL }}tags/{{ $v | urlize }}">{{ $v | lower }}</a>{{ if ne (len $.Params.tags) (add $i 1) }}, {{ end }}
     {{ end }}
 {{ end }}
 </span>


### PR DESCRIPTION
When tag contains space, e.g. foo bar:
- Hugo generates dash separated tag dir: public/tags/foo-bar/ 
- but this theme generates a tag link with space: <base_url>/tags/foo%20bar/ link

This patch fixes the link so the it is: <base_url>/tags/foo-bar/

Note that when tag has any uppercase, Hugo will still generate tag dir with lowercase, which urlize also handles.
