### PR TITLE
Fix reflect error when building site

### DIFF
--- a/layouts/partials/article-header.html
+++ b/layouts/partials/article-header.html
@@ -4,9 +4,11 @@
 <h2><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h2>
 {{ end }}
 <footer class="post-info">{{ .Site.Data.l10n.article.posted_on }} <span class="post-meta"><time datetime="{{ .Date.Format "2006.01.02" }}">{{ .Date.Format "2006.01.02" }}</time>
-{{ if gt (len .Params.tags) 0 }}&middot; {{ .Site.Data.l10n.article.tagged_in }}
-    {{ range $i, $v := .Params.tags }}
-    <a href="{{ $.Site.BaseURL }}tags/{{ $v | urlize }}">{{ $v | lower }}</a>{{ if ne (len $.Params.tags) (add $i 1) }}, {{ end }}
+{{ if isset .Params "tags" }}
+    {{ if gt (len .Params.tags) 0 }}&middot; {{ .Site.Data.l10n.article.tagged_in }}
+        {{ range $i, $v := .Params.tags }}
+        <a href="{{ $.Site.BaseURL }}tags/{{ $v | urlize }}">{{ $v | lower }}</a>{{ if ne (len $.Params.tags) (add $i 1) }}, {{ end }}
+        {{ end }}
     {{ end }}
 {{ end }}
 </span>


### PR DESCRIPTION
If a post has no tags set at all in the front matter, building the site produces some warnings.

`reflect: call of reflect.Value.Type on zero Value`

By checking if the `.Params.tags` is set before accessing it, these warnings are squashed
