### PR TITLE
Allow custom css

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,6 +17,7 @@ theme = "hugo-minimalist-theme"
     header_background = "img/desk.jpg"
     header_title = "Customizable header title"
     copyright = "Powered by [Hugo](http://gohugo.io)."
+    custom_css = ['css/custom-styles.css']
 
     # Enable gogle analytics by entering your tracking code
     google_analytics = ""

--- a/exampleSite/static/css/custom-styles.css
+++ b/exampleSite/static/css/custom-styles.css
@@ -1,0 +1,4 @@
+/*overrides post date/time/tags to make it more bold*/
+.post-info {
+  font-weight: 500;
+}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,6 +16,9 @@
         <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}apple-touch-icon.png" />
         <link rel="stylesheet" href="{{ .Site.BaseURL }}css/highlightjs/monokai.css">
         <script src="{{ .Site.BaseURL }}js/vendor/modernizr-2.8.0.min.js"></script>
+        {{ range .Site.Params.custom_css }}
+          <link rel="stylesheet" href="{{ . | absURL }}">
+        {{ end }}
         <style>
         .site-header h2 .logo {
         background: url({{ .Site.BaseURL }}{{ .Site.Params.header_background }}) no-repeat 0 0;


### PR DESCRIPTION
Borrowed inspiration from this guy https://github.com/digitalcraftsman/hugo-icarus-theme

Now host site `confit.toml` just needs
```toml
[params]
    #assuming styles in static/css
    custom_css = ['css/foo.css', 'css/bar.css']
# ...
```
and theme will add custom css files.

Is this something we can get added to the minimalist theme? 