### PR TITLE
only render comments tag with DisqusShortname set

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,10 +8,12 @@
             {{ .Content}}
             {{ partial "article-share" . }}
         </article>
+        {{ with .Site.DisqusShortname }}
         <div class="comments">
             <h3>{{ .Site.Data.l10n.comments.comments }}</h3>
             {{ template "_internal/disqus.html" . }}
         </div>
+        {{ end }}
     </main>
     {{ partial "author" . }}
 </div>


### PR DESCRIPTION
Previously the page was always rendered with a Comment tag even if the DisqusShortname was not set (to disabled comments for your site). This change adds a check for that scenario to not render it anymore.