### PR TITLE
Use if instead of with to avoid template error

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
             {{ .Content}}
             {{ partial "article-share" . }}
         </article>
-        {{ with .Site.DisqusShortname }}
+        {{ if .Site.DisqusShortname }}
         <div class="comments">
             <h3>{{ .Site.Data.l10n.comments.comments }}</h3>
             {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
When displaying the comments, Hugo would not generate the posts because of an error:
```
ERROR 2017/09/03 17:39:37 Error while rendering "page": template: theme/_default/single.html:13:24: executing "theme/_default/single.html" at <.Site.Data.l10n.comm...>: can't evaluate field Site in type string
```

The problem happens because to display disqus comments we wrap the block in a with instead of an if, changing the current context to the `.Site.DisqusShortname` text value. This fixes the error by using a simple `if` instead of `with`