### PR TITLE
Function "now" not defined

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <footer class="main-footer">
   <div class="container clearfix">
         <a class="icon-rss" href="{{ "post/index.xml" | absURL }}" title="RSS"></a>
-        <p>&copy; {{ now.Format "2006" }} &middot; {{ .Site.Params.copyright | markdownify }}</p>
+        <p>&copy; {{ time.now.Format "2006" }} &middot; {{ .Site.Params.copyright | markdownify }}</p>
   </div>
 </footer>
 


### PR DESCRIPTION
Repair:
`ERROR: template.go:495: Failed to add template theme/partials/footer.html in path test/hugo-minimalist-theme/layouts/partials/footer.html: template: theme/partials/footer.html:4: function "now" not defined`
`ERROR: template.go:529: template: theme/partials/footer.html:4: function "now" not defined`
